### PR TITLE
fixed mobile view

### DIFF
--- a/src/scss/_links.scss
+++ b/src/scss/_links.scss
@@ -19,6 +19,8 @@
 .links {
   display: flex;
   margin-top: 35px;
+  flex-wrap: wrap;
+  justify-content: center;
 
   .link {
     transition: .3s;


### PR DESCRIPTION
The links would overflow when the screen width wasn't wide enough, I fixed it. With the modifications they will wrap once the screen isn't wide enough to fit them all. I also had to add a fixed width property because the fields wouldn't align without it.